### PR TITLE
update no-longer-functioning mapbox tiles

### DIFF
--- a/app/views/layouts/nsfus_solidarity/_nsf_map_core_leaflet_search_results.rhtml
+++ b/app/views/layouts/nsfus_solidarity/_nsf_map_core_leaflet_search_results.rhtml
@@ -88,8 +88,8 @@ L.control.zoom({position: 'topright'}).addTo(map);
 map.fitBounds([[x1-dx,y1-dy],[x2+dx,y2+dy]]);
 
 var mapbox =
-  'http://{s}.tiles.mapbox.com/v4/solidarityeconomy.d591ea8d' +
-  '/{z}/{x}/{y}.png?access_token={accessToken}'
+  'https://api.mapbox.com/styles/v1/{id}/tiles' +
+  '/{z}/{x}/{y}?access_token={accessToken}';
 
 var attrib = 
 	"<a href='https://www.mapbox.com/about/maps/' " +
@@ -100,7 +100,10 @@ var attrib =
 L.tileLayer(mapbox, {
     attribution: attrib,
     maxZoom: 18,
-    accessToken: mapbox_accessToken
+    accessToken: mapbox_accessToken,
+    tileSize: 512,
+    zoomOffset: -1,
+    id: 'mapbox/streets-v11'
 }).addTo(map);
 map.attributionControl.setPrefix(
     '<a href="http://leafletjs.com" ' +

--- a/app/views/layouts/nsfus_solidarity/_nsf_map_server_side_cluster_leaflet.rhtml
+++ b/app/views/layouts/nsfus_solidarity/_nsf_map_server_side_cluster_leaflet.rhtml
@@ -107,8 +107,9 @@ function show_map(){
 		  {padding: [20, 20]}
   );
 
-  var mapbox = 'https://{s}.tiles.mapbox.com/v4/solidarityeconomy.d591ea8d' +
-  '/{z}/{x}/{y}.png?access_token={accessToken}'
+  var mapbox =
+    'https://api.mapbox.com/styles/v1/{id}/tiles' +
+    '/{z}/{x}/{y}?access_token={accessToken}';
 
   var attrib = "<a href='https://www.mapbox.com/about/maps/' " +
 	    "target='_blank'>&copy; Mapbox &copy; " +
@@ -130,9 +131,12 @@ function show_map(){
   markerGroup.addTo(map);
 
   L.tileLayer(mapbox, {
-      attribution: attrib,
-      maxZoom: 18,
-      accessToken: mapbox_accessToken
+    attribution: attrib,
+    maxZoom: 18,
+    accessToken: mapbox_accessToken,
+    tileSize: 512,
+    zoomOffset: -1,
+    id: 'mapbox/streets-v11'
   }).addTo(map);
   map.attributionControl.setPrefix(
       '<a href="http://leafletjs.com" ' +

--- a/app/views/search/_map_core_leaflet.rhtml
+++ b/app/views/search/_map_core_leaflet.rhtml
@@ -79,8 +79,8 @@ L.control.zoom({position: 'topright'}).addTo(map);
 map.fitBounds([[x1-dx,y1-dy],[x2+dx,y2+dy]]);
 
 var mapbox =
-  'http://{s}.tiles.mapbox.com/v4/solidarityeconomy.d591ea8d' +
-  '/{z}/{x}/{y}.png?access_token={accessToken}'
+  'https://api.mapbox.com/styles/v1/{id}/tiles' +
+  '/{z}/{x}/{y}?access_token={accessToken}';
 
 var attrib =
 	"<a href='https://www.mapbox.com/about/maps/' " +
@@ -91,7 +91,10 @@ var attrib =
 L.tileLayer(mapbox, {
     attribution: attrib,
     maxZoom: 18,
-    accessToken: mapbox_accessToken
+    accessToken: mapbox_accessToken,
+    tileSize: 512,
+    zoomOffset: -1,
+    id: 'mapbox/streets-v11'
 }).addTo(map);
 
 /**  solidarity-specific part ends here   */

--- a/public/javascripts/markers_and_clusters.js
+++ b/public/javascripts/markers_and_clusters.js
@@ -94,12 +94,15 @@ function show_continental_US_map(div_name){
     markerGroup.addTo(map);
 
     var tile_layer = L.tileLayer(
-	'http://{s}.tiles.mapbox.com/v4/solidarityeconomy.d591ea8d' +
-	'/{z}/{x}/{y}.png?access_token={accessToken}',
-	{
-	    maxZoom: 18, // is this needed?
-	    attribution: atrib,
-	    accessToken: mapbox_accessToken
+      'https://api.mapbox.com/styles/v1/{id}/tiles' +
+        '/{z}/{x}/{y}?access_token={accessToken}',
+      {
+          maxZoom: 18, // is this needed?
+          attribution: atrib,
+          accessToken: mapbox_accessToken,
+          tileSize: 512,
+          zoomOffset: -1,
+          id: 'mapbox/streets-v11'
 	}
     );
 


### PR DESCRIPTION
Mapbox tiles have changed, see https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4

This switches to a currently-supported tile.